### PR TITLE
Use HTTP compliant timestamp format string

### DIFF
--- a/tapalcatl_server/handler.go
+++ b/tapalcatl_server/handler.go
@@ -462,7 +462,11 @@ func MetatileHandler(p Parser, metatileSize int, mimeMap map[string]string, stor
 		headers := rw.Header()
 		headers.Set("Content-Type", parseResult.ContentType)
 		if lastMod := storageResp.LastModified; lastMod != nil {
-			lastModifiedFormatted := lastMod.Format(time.RFC1123Z)
+			// important! we must format times in an HTTP-compliant way, which
+			// apparently doesn't match any existing Go time format string, so the
+			// recommended way is to switch to UTC and use the format string that
+			// the net/http package exposes.
+			lastModifiedFormatted := lastMod.UTC().Format(http.TimeFormat)
 			headers.Set("Last-Modified", lastModifiedFormatted)
 			reqState.storageMetadata.hasLastModified = true
 		}

--- a/tapalcatl_server/handler_test.go
+++ b/tapalcatl_server/handler_test.go
@@ -129,8 +129,8 @@ func TestHandlerHit(t *testing.T) {
 	}
 
 	etag := "1234"
-	lastModifiedStr := "Thu, 17 Nov 2016 12:27:00 +0000"
-	lastModified, err := time.Parse(time.RFC1123Z, lastModifiedStr)
+	lastModifiedStr := "Thu, 17 Nov 2016 12:27:00 GMT"
+	lastModified, err := time.Parse(http.TimeFormat, lastModifiedStr)
 	if err != nil {
 		t.Fatalf("Couldn't parse time %s: %s", lastModifiedStr, err)
 	}

--- a/tapalcatl_server/server.go
+++ b/tapalcatl_server/server.go
@@ -87,6 +87,7 @@ func (h *handlerConfig) Set(line string) error {
 // try and parse a range of different date formats which are allowed by HTTP.
 func parseHTTPDates(date string) (*time.Time, error) {
 	time_layouts := []string{
+		http.TimeFormat,
 		time.RFC1123, time.RFC1123Z,
 		time.RFC822, time.RFC822Z,
 		time.RFC850, time.ANSIC,
@@ -103,7 +104,7 @@ func parseHTTPDates(date string) (*time.Time, error) {
 	}
 
 	// give the error for our preferred format
-	_, err = time.Parse(time.RFC1123, date)
+	_, err = time.Parse(http.TimeFormat, date)
 	return nil, err
 }
 

--- a/tapalcatl_server/storage_test.go
+++ b/tapalcatl_server/storage_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/tilezen/tapalcatl"
+	"net/http"
 	"testing"
 	"time"
 )
@@ -95,9 +96,11 @@ func TestS3Storage(t *testing.T) {
 	if lastMod == nil {
 		t.Fatalf("Missing last modified from storage")
 	}
-	// should be formatted in RFC 822 / 1123 format
-	expLastModStr := "Thu, 17 Nov 2016 12:27:00 +0000"
-	lastModStr := lastMod.Format(time.RFC1123Z)
+	// should be formatted in HTTP standard way, which means the GMT on the end
+	// is intentional, and shouldn't be UTC or +0000 or Z, despite all of those
+	// being better choices.
+	expLastModStr := "Thu, 17 Nov 2016 12:27:00 GMT"
+	lastModStr := lastMod.UTC().Format(http.TimeFormat)
 	if expLastModStr != lastModStr {
 		t.Fatalf("Expected Last-Modified to be %#v, but got %#v", expLastModStr, lastModStr)
 	}


### PR DESCRIPTION
We had been using RFC1123 and RFC1123Z formats, but closer reading of the HTTP spec reveals that the format string should be different from either of those standards. Instead, it must be in UTC and have the timezone string "GMT" always. Happily, Go already has to deal with this WTF, so the `net/http` package exposes a `TimeFormat` constant which we can re-use.

Connects to #18.

@rmarianski, @iandees could you review, please?