### PR TITLE
Update metatile support

### DIFF
--- a/metatile.go
+++ b/metatile.go
@@ -15,10 +15,10 @@ func (t TileCoord) FileName() string {
 	return fmt.Sprintf("%d/%d/%d.%s", t.Z, t.X, t.Y, t.Format)
 }
 
-// isPowerOfTwo return true when the given integer is a power of two.
+// IsPowerOfTwo return true when the given integer is a power of two.
 // See https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
 // for details.
-func isPowerOfTwo(i int) bool {
+func IsPowerOfTwo(i int) bool {
 	if i > 0 {
 		return (i & (i - 1)) == 0
 	}
@@ -57,11 +57,11 @@ func sizeToZoom(v uint) uint {
 // call MetaAndOffset(2, 2).
 func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord, err error) {
 	// check that sizes are powers of two before proceeding.
-	if !isPowerOfTwo(metaSize) {
+	if !IsPowerOfTwo(metaSize) {
 		err = fmt.Errorf("Metatile size is required to be a power of two, but %d is not.", metaSize)
 		return
 	}
-	if !isPowerOfTwo(tileSize) {
+	if !IsPowerOfTwo(tileSize) {
 		err = fmt.Errorf("Tile size is required to be a power of two, but %d is not.", tileSize)
 		return
 	}

--- a/metatile.go
+++ b/metatile.go
@@ -38,7 +38,7 @@ func sizeToZoom(v uint) uint {
 	var i int
 
 	for i = 4; i >= 0; i-- {
-		if v & b[i] != 0 {
+		if (v & b[i]) != 0 {
 			v >>= S[i]
 			r |= S[i]
 		}

--- a/metatile.go
+++ b/metatile.go
@@ -15,15 +15,78 @@ func (t TileCoord) FileName() string {
 	return fmt.Sprintf("%d/%d/%d.%s", t.Z, t.X, t.Y, t.Format)
 }
 
-func (t TileCoord) MetaAndOffset(size int) (meta, offset TileCoord) {
-	meta.Z = t.Z
-	meta.X = size * (t.X / size)
-	meta.Y = size * (t.Y / size)
+// isPowerOfTwo return true when the given integer is a power of two.
+// See https://graphics.stanford.edu/~seander/bithacks.html#DetermineIfPowerOf2
+// for details.
+func isPowerOfTwo(i int) bool {
+	if i > 0 {
+		return (i & (i - 1)) == 0
+	}
+	return false
+}
+
+// sizeToZoom returns the zoom equivalent to a metatile size, meaning that
+// there are size * size tiles at this zoom level. Input size must be a
+// power of two.
+//
+// Algorithm from: https://graphics.stanford.edu/~seander/bithacks.html#IntegerLog
+// as Go seems to lack an integer Log2 in its math library.
+func sizeToZoom(v uint) uint {
+	var b = [...]uint{0x2, 0xC, 0xF0, 0xFF00, 0xFFFF0000}
+	var S = [...]uint{1, 2, 3, 4, 16}
+	var r uint = 0
+	var i int
+
+	for i = 4; i >= 0; i-- {
+		if v & b[i] != 0 {
+			v >>= S[i]
+			r |= S[i]
+		}
+	}
+
+	return r
+}
+
+// MetaAndOffset returns the metatile coordinate and the offset within it for
+// this TileCoord object. The argument metaSize indicates the size of the
+// metatile and tileSize indicates the size of the tile within the metatile
+// that you want to extract, both in units of "standard" 256px tiles.
+//
+// For example, to extract a 1x1 regular 256px tile from a 2x2 metatile, one
+// would call MetaAndOffset(2, 1). To extract the 512px tile from the same,
+// call MetaAndOffset(2, 2).
+func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord, err error) {
+	// check that sizes are powers of two before proceeding.
+	if !isPowerOfTwo(metaSize) {
+		err = fmt.Errorf("Metatile size is required to be a power of two, but %d is not.", metaSize)
+		return
+	}
+	if !isPowerOfTwo(tileSize) {
+		err = fmt.Errorf("Tile size is required to be a power of two, but %d is not.", tileSize)
+		return
+	}
+
+	// now we can calculate the delta in zoom level, knowing that both must be
+	// powers of two, and hence positive.
+	metaZoom := sizeToZoom(uint(metaSize))
+	tileZoom := sizeToZoom(uint(tileSize))
+	if tileZoom > metaZoom {
+		err = fmt.Errorf("Tile size must not be greater than metatile size, but %d > %d.", tileSize, metaSize)
+		return
+	}
+	deltaZ := metaZoom - tileZoom
+
+	// note that the uint->int conversion is technically a narrowing, but cannot
+	// overflow because we know it contains the difference of two Log2s, which
+	// cannot be larger than 32.
+	meta.Z = t.Z - int(deltaZ)
+	meta.X = t.X >> deltaZ
+	meta.Y = t.Y >> deltaZ
 	meta.Format = "zip"
 
 	offset.Z = t.Z - meta.Z
-	offset.X = t.X - meta.X
-	offset.Y = t.Y - meta.Y
+	offset.X = t.X - (meta.X << deltaZ)
+	offset.Y = t.Y - (meta.Y << deltaZ)
 	offset.Format = t.Format
 
 	return

--- a/metatile_test.go
+++ b/metatile_test.go
@@ -77,30 +77,38 @@ func coordEquals(t *testing.T, name string, exp, act TileCoord) {
 	}
 }
 
-func checkMetaOffset(t *testing.T, size int, coord, exp_meta, exp_offset TileCoord) {
-	meta, offset := coord.MetaAndOffset(size)
+func checkMetaOffset(t *testing.T, metaSize, tileSize int, coord, exp_meta, exp_offset TileCoord) {
+	meta, offset, err := coord.MetaAndOffset(metaSize, tileSize)
+	if err != nil {
+		t.Fatalf("Expected result from MetaAndOffset, but got error: %s", err.Error())
+	}
 	coordEquals(t, "meta", exp_meta, meta)
 	coordEquals(t, "offset", exp_offset, offset)
 }
 
 func TestMetaOffset(t *testing.T) {
-	checkMetaOffset(t, 1,
+	checkMetaOffset(t, 1, 1,
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 1,
+	checkMetaOffset(t, 1, 1,
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 2,
+	checkMetaOffset(t, 2, 1,
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
-		TileCoord{Z: 12, X: 636, Y: 936, Format: "zip"},
-		TileCoord{Z: 0, X: 1, Y: 0, Format: "json"})
+		TileCoord{Z: 11, X: 318, Y: 468, Format: "zip"},
+		TileCoord{Z: 1, X: 1, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 8,
+	checkMetaOffset(t, 2, 2,
+		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
+		TileCoord{Z: 12, X: 637, Y: 936, Format: "zip"},
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
+
+	checkMetaOffset(t, 8, 1,
 		TileCoord{Z: 12, X: 637, Y: 935, Format: "json"},
-		TileCoord{Z: 12, X: 632, Y: 928, Format: "zip"},
-		TileCoord{Z: 0, X: 5, Y: 7, Format: "json"})
+		TileCoord{Z: 9, X: 79, Y: 116, Format: "zip"},
+		TileCoord{Z: 3, X: 5, Y: 7, Format: "json"})
 }

--- a/tapalcatl_server/expvar.go
+++ b/tapalcatl_server/expvar.go
@@ -9,6 +9,7 @@ import (
 
 var (
 	requestParseErrors  *expvar.Int
+	configErrors        *expvar.Int
 	storageFetchErrors  *expvar.Int
 	storageReadErrors   *expvar.Int
 	metatileReadErrors  *expvar.Int
@@ -28,6 +29,7 @@ var (
 
 func init() {
 	requestParseErrors = expvar.NewInt("requestParseErrors")
+	configErrors = expvar.NewInt("configErrors")
 	storageFetchErrors = expvar.NewInt("storageFetchErrors")
 	storageReadErrors = expvar.NewInt("storageReadErrors")
 	metatileReadErrors = expvar.NewInt("metatileReadErrors")

--- a/tapalcatl_server/handler.go
+++ b/tapalcatl_server/handler.go
@@ -401,7 +401,7 @@ func NewStatsdMetricsWriter(addr *net.UDPAddr, metricsPrefix string, logger Json
 	return smw
 }
 
-func MetatileHandler(p Parser, metatileSize int, mimeMap map[string]string, storage Storage, bufferManager BufferManager, mw metricsWriter, logger JsonLogger) http.Handler {
+func MetatileHandler(p Parser, metatileSize, tileSize int, mimeMap map[string]string, storage Storage, bufferManager BufferManager, mw metricsWriter, logger JsonLogger) http.Handler {
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 
@@ -471,7 +471,7 @@ func MetatileHandler(p Parser, metatileSize int, mimeMap map[string]string, stor
 		reqState.Coord = &parseResult.Coord
 		reqState.HttpData = &parseResult.HttpData
 
-		metaCoord, offset, err := parseResult.Coord.MetaAndOffset(metatileSize, 1)
+		metaCoord, offset, err := parseResult.Coord.MetaAndOffset(metatileSize, tileSize)
 		if err != nil {
 			configErrors.Add(1)
 			logger.Warning(LogCategory_ConfigError, "MetaAndOffset could not be calculated: %s", err.Error())

--- a/tapalcatl_server/handler_test.go
+++ b/tapalcatl_server/handler_test.go
@@ -86,7 +86,7 @@ func TestHandlerMiss(t *testing.T) {
 		"json": "application/json",
 	}
 	storage := &fakeStorage{storage: make(map[tapalcatl.TileCoord]*StorageResponse)}
-	h := MetatileHandler(parser, 1, mimes, storage, &OnDemandBufferManager{}, &nilMetricsWriter{}, &NilJsonLogger{})
+	h := MetatileHandler(parser, 1, 1, mimes, storage, &OnDemandBufferManager{}, &nilMetricsWriter{}, &NilJsonLogger{})
 
 	rw := &fakeResponseWriter{header: make(http.Header), status: 0}
 	req := &http.Request{}
@@ -147,7 +147,7 @@ func TestHandlerHit(t *testing.T) {
 		},
 	}
 
-	h := MetatileHandler(parser, 1, mimes, storage, &OnDemandBufferManager{}, &nilMetricsWriter{}, &NilJsonLogger{})
+	h := MetatileHandler(parser, 1, 1, mimes, storage, &OnDemandBufferManager{}, &nilMetricsWriter{}, &NilJsonLogger{})
 
 	rw := &fakeResponseWriter{header: make(http.Header), status: 0}
 	req := &http.Request{}


### PR DESCRIPTION
Tapalcatl had been written to assume single-zoom metatiles, but we are now expecting to use ones with a zoom range. This patch updates the calculation of metatile coordinates to match what we're expecting from tilequeue, and makes the tile size configurable on a per-pattern basis in anticipation of 512px tiles.
