### PR TITLE
Close zip file reader from metatile.

### DIFF
--- a/tapalcatl_server/handler.go
+++ b/tapalcatl_server/handler.go
@@ -570,6 +570,8 @@ func MetatileHandler(p Parser, metatileSize, tileSize int, mimeMap map[string]st
 			reqState.ResponseState = ResponseState_Error
 			return
 		}
+		// make sure to close zip file reader
+		defer reader.Close()
 		reqState.ResponseSize = int(formatSize)
 
 		rw.WriteHeader(http.StatusOK)


### PR DESCRIPTION
This probably doesn't matter much, as it's a pointer to bytes in memory. But this might be a memory leak, so we ought to do the right thing.