### PR TITLE
Clamp to 0/0/0

### DIFF
--- a/metatile.go
+++ b/metatile.go
@@ -79,15 +79,32 @@ func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord
 	// note that the uint->int conversion is technically a narrowing, but cannot
 	// overflow because we know it contains the difference of two Log2s, which
 	// cannot be larger than 32.
-	meta.Z = t.Z - int(deltaZ)
-	meta.X = t.X >> deltaZ
-	meta.Y = t.Y >> deltaZ
-	meta.Format = "zip"
+	iDeltaZ := int(deltaZ)
 
-	offset.Z = t.Z - meta.Z
-	offset.X = t.X - (meta.X << deltaZ)
-	offset.Y = t.Y - (meta.Y << deltaZ)
-	offset.Format = t.Format
+	// if the reduction in zoom due to the metatile size would take us "outside
+	// the world" and leave meta.Z < 0, then we just clamp to zero.
+	if t.Z < iDeltaZ {
+		meta.Z = 0
+		meta.X = 0
+		meta.Y = 0
+		meta.Format = "zip"
+
+		offset.Z = 0
+		offset.X = 0
+		offset.Y = 0
+		offset.Format = t.Format
+
+	} else {
+		meta.Z = t.Z - iDeltaZ
+		meta.X = t.X >> deltaZ
+		meta.Y = t.Y >> deltaZ
+		meta.Format = "zip"
+
+		offset.Z = t.Z - meta.Z
+		offset.X = t.X - (meta.X << deltaZ)
+		offset.Y = t.Y - (meta.Y << deltaZ)
+		offset.Format = t.Format
+	}
 
 	return
 }

--- a/metatile_test.go
+++ b/metatile_test.go
@@ -111,4 +111,16 @@ func TestMetaOffset(t *testing.T) {
 		TileCoord{Z: 12, X: 637, Y: 935, Format: "json"},
 		TileCoord{Z: 9, X: 79, Y: 116, Format: "zip"},
 		TileCoord{Z: 3, X: 5, Y: 7, Format: "json"})
+
+	// check that the "512px" 0/0/0 tile is accessible.
+	checkMetaOffset(t, 2, 2,
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
+
+	// check that when the metatile would be smaller than the world (i.e: zoom < 0) then it just stops at 0 and we get the offset to the 0/0/0 tile.
+	checkMetaOffset(t, 2, 1,
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
+		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 }


### PR DESCRIPTION
When a 256px tile at 0/0/0 is requested and the metatile size is 2, that leads to trying to request a metatile at -1/0/0, which doesn't exist. Instead, we clamp to 0/0/0, effectively returning the 512px 0/0/0 tile for 256px requests. This tile is at nominal zoom 1, which means that zoom 0 as a separate, styleable zoom.