### PR TITLE
Fix metatile offset calculation

### DIFF
--- a/pkg/tile/metatile.go
+++ b/pkg/tile/metatile.go
@@ -100,11 +100,13 @@ func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord
 		meta.Y = t.Y >> deltaZ
 		meta.Format = "zip"
 
-		offset.Z = t.Z - meta.Z
-		offset.X = t.X - (meta.X << deltaZ)
-		offset.Y = t.Y - (meta.Y << deltaZ)
-		offset.Format = t.Format
 	}
+
+	actualDeltaZ := t.Z - meta.Z
+	offset.Z = actualDeltaZ
+	offset.X = t.X - (meta.X << actualDeltaZ)
+	offset.Y = t.Y - (meta.Y << actualDeltaZ)
+	offset.Format = t.Format
 
 	return
 }


### PR DESCRIPTION
I was running into problems getting vector tiles out of metatiles with a couple recent builds. I think this offset calculation was in the wrong spot because when I made this change the tiles started working again.