### PR TITLE
Add support for preview.html-style page to help visualize vector tiles

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -290,6 +290,19 @@ func main() {
 
 	}
 
+	if hc.Preview != nil {
+		if hc.Preview.Path == nil || hc.Preview.Template == nil {
+			systemLogger.Fatalf("ERROR: Preview must have path and template specified")
+		}
+
+		fileHandler, err := handler.NewFileHandler(*hc.Preview.Template)
+		if err != nil {
+			systemLogger.Fatalf("ERROR: Couldn't load preview template: %+v", err)
+		}
+
+		r.Handle(*hc.Preview.Path, fileHandler).Methods("GET")
+	}
+
 	if len(healthcheck) > 0 {
 		storagesToCheck := make([]storage.Storage, len(healthCheckStorages))
 		i := 0

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -295,7 +295,12 @@ func main() {
 			systemLogger.Fatalf("ERROR: Preview must have path and template specified")
 		}
 
-		fileHandler, err := handler.NewFileHandler(*hc.Preview.Template)
+		var templateData map[string]interface{}
+		if hc.Preview.Data != nil {
+			templateData = *hc.Preview.Data
+		}
+
+		fileHandler, err := handler.NewFileHandler(*hc.Preview.Template, templateData)
 		if err != nil {
 			systemLogger.Fatalf("ERROR: Couldn't load preview template: %+v", err)
 		}

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -48,6 +48,8 @@ type previewConfig struct {
 	Path *string
 	// Template is a path on disk to the template to serve at the above URL.
 	Template *string
+	// Data is the data to use when rendering the template.
+	Data *map[string]interface{}
 }
 
 type storageDefinition struct {

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -10,6 +10,7 @@ type HandlerConfig struct {
 	Storage map[string]storageDefinition
 	Pattern map[string]routeHandlerConfig
 	Mime    map[string]string
+	Preview *previewConfig
 }
 
 func (h *HandlerConfig) String() string {
@@ -38,6 +39,15 @@ type awsConfig struct {
 	Region *string
 	// attempt to assume this AWS IAM role when making requests to S3
 	Role *string
+}
+
+// previewConfig is the container for configuring a preview webpage.
+// Both attributes are required if preview is specified.
+type previewConfig struct {
+	// Path is the HTTP path to register to serve the given template.
+	Path *string
+	// Template is a path on disk to the template to serve at the above URL.
+	Template *string
 }
 
 type storageDefinition struct {

--- a/pkg/handler/preview.go
+++ b/pkg/handler/preview.go
@@ -29,6 +29,11 @@ func NewFileHandler(filename string) (http.Handler, error) {
 		return nil, fmt.Errorf("couldn't read file %s for handler: %w", filename, err)
 	}
 
+	err = f.Close()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't close file %s after reading for handler: %w", filename, err)
+	}
+
 	handler := fileHandler{data: d}
 
 	return handler, nil

--- a/pkg/handler/preview.go
+++ b/pkg/handler/preview.go
@@ -15,6 +15,8 @@ func (f fileHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request
 	writer.Write(f.data.Bytes())
 }
 
+// NewFileHandler parses the filename given as a text template and renders it with the given templateData.
+// It returns an HTTP handler that serves the resulting rendered data to all requests.
 func NewFileHandler(filename string, templateData map[string]interface{}) (http.Handler, error) {
 	tpl, err := template.ParseFiles(filename)
 	if err != nil {

--- a/pkg/handler/preview.go
+++ b/pkg/handler/preview.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+type fileHandler struct {
+	data *bytes.Buffer
+}
+
+func (f fileHandler) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
+	writer.Write(f.data.Bytes())
+}
+
+func NewFileHandler(filename string) (http.Handler, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't open file %s for handler: %w", filename, err)
+	}
+
+	d := bytes.NewBuffer(nil)
+
+	_, err = io.Copy(d, f)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read file %s for handler: %w", filename, err)
+	}
+
+	handler := fileHandler{data: d}
+
+	return handler, nil
+}

--- a/static/preview.html
+++ b/static/preview.html
@@ -40,7 +40,7 @@
             ],
             sources: {
                 mapzen: {
-                    url: 'tilezen/vector/v1/all/{z}/{x}/{y}.mvt',
+                    url: '{{ .tilepath }}',
                     url_params: {
                     },
                     tile_size: 512,

--- a/static/preview.html
+++ b/static/preview.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <title>Nextzen Tangram Demo</title>
+    <link rel="stylesheet" href="https://www.nextzen.org/js/nextzen.css" />
+    <script type="text/javascript" src="https://www.nextzen.org/js/nextzen.min.js"></script>
+
+    <style>
+        body {
+            margin: 0px;
+            border: 0px;
+            padding: 0px;
+        }
+
+        #map {
+            height: 100%;
+            width: 100%;
+            position: absolute;
+        }
+
+    </style>
+</head>
+
+<body>
+<div id="map"></div>
+
+<script>
+    var map = L.Nextzen.map('map', {
+    attribution: '<a href="https://github.com/tangrams" target="_blank">Tangram</a> | <a href="http://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a> | <a href="https://www.nextzen.org/" target="_blank">Nextzen</a>',
+        tangramOptions: {
+        scene: {
+            import: [
+                'https://www.nextzen.org/carto/bubble-wrap-style/10/bubble-wrap-style.zip',
+                'https://www.nextzen.org/carto/bubble-wrap-style/10/themes/bubble-wrap-road-shields-usa.zip',
+                'https://www.nextzen.org/carto/bubble-wrap-style/10/themes/bubble-wrap-road-shields-international.zip',
+                'https://www.nextzen.org/carto/bubble-wrap-style/10/themes/label-10.zip'
+            ],
+            sources: {
+                mapzen: {
+                    url: 'tilezen/vector/v1/all/{z}/{x}/{y}.mvt',
+                    url_params: {
+                    },
+                    tile_size: 512,
+                    max_zoom: 16
+                }
+            }
+        }
+    }});
+    map.setView([33.0, -12.3], 2);
+    L.Nextzen.hash({map: map});
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This adds a bit of configuration to support serving a page with a Tangram map that points to the tiles this service serves. This is enormously helpful with debugging.