### PR TITLE
Add support for max detail zoom in metatiles

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -68,6 +68,7 @@ func main() {
      storage name string -> {
         Type string storage type, can be "s3" or "file
         MetatileSize int      Number of 256px tiles in each dimension of the metatile.
+        MetatileMaxDetailZoom int Maximum level of detail available in the metatiles.
         TileSize int        Size of tile in 256px tile units.
 
        (s3 storage)
@@ -173,6 +174,7 @@ func main() {
 		if !tile.IsPowerOfTwo(metatileSize) {
 			logFatalCfgErr(logger, "Metatile size must be power of two, but %d is not", metatileSize)
 		}
+
 		tileSize := 1
 		if sd.TileSize != nil {
 			tileSize = *sd.TileSize
@@ -183,6 +185,12 @@ func main() {
 		if !tile.IsPowerOfTwo(tileSize) {
 			logFatalCfgErr(logger, "Tile size must be power of two, but %d is not", tileSize)
 		}
+
+		metatileMaxDetailZoom := 0
+		if sd.MetatileMaxDetailZoom != nil {
+			metatileMaxDetailZoom = *sd.MetatileMaxDetailZoom
+		}
+
 		layer := sd.Layer
 		if rhc.Layer != nil {
 			layer = *rhc.Layer
@@ -274,7 +282,7 @@ func main() {
 				MimeMap: hc.Mime,
 			}
 
-			h := handler.MetatileHandler(parser, metatileSize, tileSize, hc.Mime, stg, bufferManager, mw, logger)
+			h := handler.MetatileHandler(parser, metatileSize, tileSize, metatileMaxDetailZoom, hc.Mime, stg, bufferManager, mw, logger)
 			gzipped := gziphandler.GzipHandler(h)
 
 			r.Handle(reqPattern, gzipped).Methods("GET")

--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,5 @@ require (
 	github.com/imkira/go-interpol v1.1.0
 	github.com/namsral/flag v1.7.4-pre
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c
-	github.com/whosonfirst/go-httpony v0.0.0-20161015171754-c345d005e965
+	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
 )

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/whosonfirst/go-httpony v0.0.0-20161015171754-c345d005e965 h1:54w5tM+DPml6V2Zf1Hzu494beg07mc1xhBcJXXZpbpw=
-github.com/whosonfirst/go-httpony v0.0.0-20161015171754-c345d005e965/go.mod h1:HZxPUcBYWzvCGEjHCQCYjD1dknIlrjtUu/djubWE7aI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=

--- a/pkg/config/handler.go
+++ b/pkg/config/handler.go
@@ -45,7 +45,11 @@ type storageDefinition struct {
 
 	// common fields across all storage types
 	// these can be overridden in specific storage configuration
+
+	// MetatileSize is the size of a tile contained in a metatile bundle (relative to a 256px tile)
 	MetatileSize int
+	// MetatileMaxDetailZoom is the zoom level where all features are present in the tile
+	MetatileMaxDetailZoom *int
 
 	// TileSize indicates the size of tile for this pattern. The default is 1.
 	TileSize *int

--- a/pkg/handler/handler_test.go
+++ b/pkg/handler/handler_test.go
@@ -101,7 +101,7 @@ func TestHandlerMiss(t *testing.T) {
 		"json": "application/json",
 	}
 	storage := &fakeStorage{storage: make(map[tile.TileCoord]*storage.StorageResponse)}
-	h := MetatileHandler(parser, 1, 1, mimes, storage, &buffer.OnDemandBufferManager{}, &metrics.NilMetricsWriter{}, &NilJsonLogger{})
+	h := MetatileHandler(parser, 1, 1, 0, mimes, storage, &buffer.OnDemandBufferManager{}, &metrics.NilMetricsWriter{}, &NilJsonLogger{})
 
 	rw := &fakeResponseWriter{header: make(http.Header), status: 0}
 	req := &http.Request{}
@@ -140,7 +140,7 @@ func TestHandlerHit(t *testing.T) {
 		},
 	}
 
-	h := MetatileHandler(parser, 1, 1, mimes, stg, &buffer.OnDemandBufferManager{}, &metrics.NilMetricsWriter{}, &NilJsonLogger{})
+	h := MetatileHandler(parser, 1, 1, 0, mimes, stg, &buffer.OnDemandBufferManager{}, &metrics.NilMetricsWriter{}, &NilJsonLogger{})
 
 	rw := &fakeResponseWriter{header: make(http.Header), status: 0}
 	req := &http.Request{}

--- a/pkg/handler/metatile.go
+++ b/pkg/handler/metatile.go
@@ -18,7 +18,14 @@ import (
 	"github.com/tilezen/tapalcatl/pkg/tile"
 )
 
-func MetatileHandler(p Parser, metatileSize, tileSize int, mimeMap map[string]string, storage storage.Storage, bufferManager buffer.BufferManager, mw metrics.MetricsWriter, logger log.JsonLogger) http.Handler {
+func MetatileHandler(
+	p Parser,
+	metatileSize, tileSize, metatileMaxDetailZoom int,
+	mimeMap map[string]string,
+	storage storage.Storage,
+	bufferManager buffer.BufferManager,
+	mw metrics.MetricsWriter,
+	logger log.JsonLogger) http.Handler {
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 
@@ -84,7 +91,7 @@ func MetatileHandler(p Parser, metatileSize, tileSize int, mimeMap map[string]st
 		reqState.Format = reqState.Coord.Format
 		reqState.HttpData = parseResult.HttpData
 
-		metaCoord, offset, err := metatileData.Coord.MetaAndOffset(metatileSize, tileSize)
+		metaCoord, offset, err := metatileData.Coord.MetaAndOffset(metatileSize, tileSize, metatileMaxDetailZoom)
 		if err != nil {
 			logger.Warning(log.LogCategory_ConfigError, "MetaAndOffset could not be calculated: %s", err.Error())
 			http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/pkg/tile/metatile.go
+++ b/pkg/tile/metatile.go
@@ -113,12 +113,13 @@ func (t TileCoord) MetaAndOffset(metaSize, tileSize, metatileMaxDetailZoom int) 
 		meta.X = t.X >> iDeltaZ
 		meta.Y = t.Y >> iDeltaZ
 		meta.Format = "zip"
-
-		offset.Z = t.Z - meta.Z
-		offset.X = t.X - (meta.X << deltaZ)
-		offset.Y = t.Y - (meta.Y << deltaZ)
-		offset.Format = t.Format
 	}
+
+	actualDeltaZ := t.Z - meta.Z
+	offset.Z = actualDeltaZ
+	offset.X = t.X - (meta.X << actualDeltaZ)
+	offset.Y = t.Y - (meta.Y << actualDeltaZ)
+	offset.Format = t.Format
 
 	return
 }

--- a/pkg/tile/metatile.go
+++ b/pkg/tile/metatile.go
@@ -47,6 +47,14 @@ func sizeToZoom(v uint) uint {
 	return r
 }
 
+func min(a, b int) int {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}
+
 // MetaAndOffset returns the metatile coordinate and the offset within it for
 // this TileCoord object. The argument metaSize indicates the size of the
 // metatile and tileSize indicates the size of the tile within the metatile
@@ -55,7 +63,7 @@ func sizeToZoom(v uint) uint {
 // For example, to extract a 1x1 regular 256px tile from a 2x2 metatile, one
 // would call MetaAndOffset(2, 1). To extract the 512px tile from the same,
 // call MetaAndOffset(2, 2).
-func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord, err error) {
+func (t TileCoord) MetaAndOffset(metaSize, tileSize, metatileMaxDetailZoom int) (meta, offset TileCoord, err error) {
 	// check that sizes are powers of two before proceeding.
 	if !IsPowerOfTwo(metaSize) {
 		err = fmt.Errorf("Metatile size is required to be a power of two, but %d is not.", metaSize)
@@ -89,15 +97,21 @@ func (t TileCoord) MetaAndOffset(metaSize, tileSize int) (meta, offset TileCoord
 		meta.Y = 0
 		meta.Format = "zip"
 
-		offset.Z = 0
-		offset.X = 0
-		offset.Y = 0
-		offset.Format = t.Format
-
 	} else {
+		// Allows setting a maximum detail level beyond which all features are
+		// present in the tile and requests with tileSize larger than are
+		// available can be satisfied with "smaller" tiles that are present.
+		if metatileMaxDetailZoom > 0 && t.Z-iDeltaZ > metatileMaxDetailZoom {
+			// The call to min() is here to clamp the size of the offset - the
+			// idea being that it's better to request a metatile that isn't
+			// present and 404, rather than request one that is, pay the cost
+			// of unzipping it, and find it doesn't contain the offset.
+			iDeltaZ = min(t.Z-metatileMaxDetailZoom, int(metaZoom))
+		}
+
 		meta.Z = t.Z - iDeltaZ
-		meta.X = t.X >> deltaZ
-		meta.Y = t.Y >> deltaZ
+		meta.X = t.X >> iDeltaZ
+		meta.Y = t.Y >> iDeltaZ
 		meta.Format = "zip"
 
 		offset.Z = t.Z - meta.Z

--- a/pkg/tile/metatile_test.go
+++ b/pkg/tile/metatile_test.go
@@ -77,8 +77,8 @@ func coordEquals(t *testing.T, name string, exp, act TileCoord) {
 	}
 }
 
-func checkMetaOffset(t *testing.T, metaSize, tileSize int, coord, exp_meta, exp_offset TileCoord) {
-	meta, offset, err := coord.MetaAndOffset(metaSize, tileSize)
+func checkMetaOffset(t *testing.T, metaSize, tileSize, maxDetailZoom int, coord, exp_meta, exp_offset TileCoord) {
+	meta, offset, err := coord.MetaAndOffset(metaSize, tileSize, maxDetailZoom)
 	if err != nil {
 		t.Fatalf("Expected result from MetaAndOffset, but got error: %s", err.Error())
 	}
@@ -87,40 +87,46 @@ func checkMetaOffset(t *testing.T, metaSize, tileSize int, coord, exp_meta, exp_
 }
 
 func TestMetaOffset(t *testing.T) {
-	checkMetaOffset(t, 1, 1,
+	checkMetaOffset(t, 1, 1, 0,
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 1, 1,
+	checkMetaOffset(t, 1, 1, 0,
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 2, 1,
+	checkMetaOffset(t, 2, 1, 0,
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
 		TileCoord{Z: 11, X: 318, Y: 468, Format: "zip"},
 		TileCoord{Z: 1, X: 1, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 2, 2,
+	checkMetaOffset(t, 2, 2, 0,
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "json"},
 		TileCoord{Z: 12, X: 637, Y: 936, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
-	checkMetaOffset(t, 8, 1,
+	checkMetaOffset(t, 8, 1, 0,
 		TileCoord{Z: 12, X: 637, Y: 935, Format: "json"},
 		TileCoord{Z: 9, X: 79, Y: 116, Format: "zip"},
 		TileCoord{Z: 3, X: 5, Y: 7, Format: "json"})
 
 	// check that the "512px" 0/0/0 tile is accessible.
-	checkMetaOffset(t, 2, 2,
+	checkMetaOffset(t, 2, 2, 0,
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
 
 	// check that when the metatile would be smaller than the world (i.e: zoom < 0) then it just stops at 0 and we get the offset to the 0/0/0 tile.
-	checkMetaOffset(t, 2, 1,
+	checkMetaOffset(t, 2, 1, 0,
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "zip"},
 		TileCoord{Z: 0, X: 0, Y: 0, Format: "json"})
+
+	// check that max detail zoom works as expected
+	checkMetaOffset(t, 8, 2, 13,
+		TileCoord{Z: 16, X: 37311, Y: 18976, Format: "json"},
+		TileCoord{Z: 13, X: 4663, Y: 2372, Format: "zip"},
+		TileCoord{Z: 3, X: 7, Y: 0, Format: "json"})
 }


### PR DESCRIPTION
This adds a bit of configuration and code that was added to tapalcatl-py since we created tapalcatl-go.

See the tapalcatl-py PR (https://github.com/tilezen/tapalcatl-py/pull/14) for more details about what the code is actually doing.